### PR TITLE
[fix] GitHub Action & README

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,30 +1,27 @@
 name: Thanks!
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
-    workflow_dispatch:
+  pull_request:
+    types:
+      - closed
 
 jobs:
-    update-readme:
-        runs-on: ubuntu-latest
+  update-readme:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
 
-        steps:
-        - name: Checkout Repository
-          uses: actions/checkout@main
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@main
 
-        - name: Update README
-          run: |
-            echo ">- 感谢:" >> README.md
-            echo "Author: ${{ github.event.head_commit.author.name }}" >> README.md
-            echo -e "Email: ${{ github.event.head_commit.author.email }} \n" >> README.md
+      - name: Update README
+        run: |
+          echo "> - 感谢 [@${{ github.event.head_commit.author.name }}](https://github.com/${{ github.actor }}) ${{ github.event.pull_request.title }}" >> README.md
 
-        - name: Commit and Push Changes
-          run: |
-            git config user.name "Jiahuan-bot"
-            git config user.email "cheayuki13@gmail.com"
-            git add README.md
-            git commit -m "[salute]Thanks for pr from @${{ github.event.head_commit.author.name }} "
-            git push
+      - name: Commit and Push Changes
+        run: |
+          git config user.name "Jiahuan-bot"
+          git config user.email "cheayuki13@gmail.com"
+          git add README.md
+          git commit -m "[salute]Thanks for PR from @${{ github.actor }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -27,27 +27,17 @@
 如果您对该库有任何问题或疑虑，请联系库管理员。
 
 ## 致谢
->
->- 感谢 [@ZHDI-1](https://github.com/ZHDI-1) 提供了 readme文件
->- 感谢 [@JiaHuann](https://github.com/JiaHuann) 提供了 2021-2022年 数据结构 大学物理B 期末考试试卷
->- 感谢 [@StudyingLover](https://github.com/StudyingLover) 提供了 2020-2021年 2021-2022年 高等数学A1期末考试试卷
->- 感谢 [@2233-ATRI](https://github.com/2233-ATRI)提供了部分工图和概率论相关题目答案
->- 感谢 [@纸鹿Zhilu](https://github.com/L33Z22L11) 更新了部分高等数学试卷和整理repo内容，并挂上[友链](https://cooo.site)
->- 感谢 [@Daz-3ux](https://github.com/Daz-3ux) 更新了部分概率论与数理统计试卷
->- 感谢 [@slnll](https://github.com/slnll) 更新了部分毛概试卷
->- 感谢 [@Tamaxii](https://github.com/lys122519) 更新了部分OS 计组 编译原理 微机原理试卷
->- 感谢 [@XUPTLiYipeng](https://github.com/XUPTLiYipeng) 更新了部分verilog,大物，微机，操作系统，数据库，数据结构，概率论，计组试卷
->- 感谢 [@WaterBucket0819](https://github.com/WaterBucket0819) 更新线性代数相关试卷
 
->- 感谢:
-Author: WaterBucket0819
-Email: 1415193001@qq.com 
-
->- 感谢:
-Author: 无心厌
-Email: 132572015+Syhaun@users.noreply.github.com 
-
->- 感谢:
-Author: Guiltysxul
-Email: 91719258+Guiltysxul@users.noreply.github.com 
-
+> - 感谢 [@ZHDI-1](https://github.com/ZHDI-1) 提供了 readme文件
+> - 感谢 [@JiaHuann](https://github.com/JiaHuann) 提供了 2021-2022年 数据结构 大学物理B 期末考试试卷
+> - 感谢 [@StudyingLover](https://github.com/StudyingLover) 提供了 2020-2021年 2021-2022年 高等数学A1期末考试试卷
+> - 感谢 [@2233-ATRI](https://github.com/2233-ATRI)提供了部分工图和概率论相关题目答案
+> - 感谢 [@纸鹿/Zhilu](https://github.com/L33Z22L11) 更新了部分高等数学试卷和整理repo内容，并挂上[友链](https://cooo.site)
+> - 感谢 [@Daz-3ux](https://github.com/Daz-3ux) 更新了部分概率论与数理统计试卷
+> - 感谢 [@slnll](https://github.com/slnll) 更新了部分毛概试卷
+> - 感谢 [@Tamaxii](https://github.com/lys122519) 更新了部分OS 计组 编译原理 微机原理试卷
+> - 感谢 [@XUPTLiYipeng](https://github.com/XUPTLiYipeng) 更新了部分verilog,大物，微机，操作系统，数据库，数据结构，概率论，计组试卷
+> - 感谢 [@WaterBucket0819](https://github.com/WaterBucket0819) 更新线性代数相关试卷
+> - 感谢 [@WaterBucket0819](https://github.com/WaterBucket0819) 新增高数
+> - 感谢 [@无心厌](https://github.com/Syhaun) 概率论与数理统计
+> - 感谢 [@Guiltysxul](https://github.com/Guiltysxul) 密码学


### PR DESCRIPTION
- 使 GitHub Action 只在PR合并时启动，避免其他 commit 修改 README 文件。
- GitHub Action 配置文件现在可以获取提交者的 `name` 和 `username` ，以及 Pull Request 的 `title` ，并向README 文件自动添加 `@mention` 链接和 PR 标题。
- 修正了 README 的样式，并修改 GitHub Action 配置文件以避免 README 中的 Quote block 断开。