### PR TITLE
Edit format

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -17,7 +17,7 @@ jobs:
 
         - name: Update README
           run: |
-            echo "> - 感谢 [@${{ github.event.head_commit.author.name }}](https://github.com/${{ github.event.head_commit.author.name }}) ${{ github.event.pull_request.title }}" >> README.md
+            echo "> * 感谢 [@${{ github.event.head_commit.author.name }}](https://github.com/${{ github.event.head_commit.author.name }}) ${{ github.event.pull_request.title }}" >> README.md
 
         - name: Commit and Push Changes
           run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 西安邮电大学考试试卷库
 
 欢迎来到西安邮电大学考试试卷库！该库存储了XUPT多个课程的历年考试试卷，目的是为学生提供一个宝贵的资源，帮助他们准备即将到来的考试。
+
 非常欢迎和感谢各位积极提供资源！
 
 ## 如何使用
@@ -53,4 +54,4 @@
 > * 感谢 [@g0ubu1i](https://github.com/g0ubu1i)
 > * 感谢 [@wdcww](https://github.com/wdcww)
 > * 感谢 [@FSchorner](https://github.com/FSchorner)
-> - 感谢 [@bifangzi](https://github.com/bifangzi) 
+> * 感谢 [@bifangzi](https://github.com/bifangzi)


### PR DESCRIPTION
注意到README的上下文使用的无序列表符号不一致（上文为“\*”下文为“-”）。
可能是由于在上文使用“\*”的情况下，workflows的blank.yml却设定新增的无序列表以“-”作为符号。 参考VSCode和Typora的Markdown无序列表格式，建议统一为“\*”。
此外，在README中的两段没有空行的正文中间加了空行，原本的格式导致两行被渲染为同一个段落。
已经在Github网页和本地观察到以“*”和“-”开头的无序列表之间出现了不应出现的间距更大的行距，因此统一符号可以确保渲染正确